### PR TITLE
CuotaRepercutida must be empty when OperacionExenta has a value

### DIFF
--- a/doc/breakdown.go
+++ b/doc/breakdown.go
@@ -51,7 +51,6 @@ func newDesglose(inv *bill.Invoice) (*Desglose, error) {
 func buildDetalleDesglose(c *tax.CategoryTotal, r *tax.RateTotal) (*DetalleDesglose, error) {
 	detalle := &DetalleDesglose{
 		BaseImponibleOImporteNoSujeto: r.Base.String(),
-		CuotaRepercutida:              r.Amount.String(),
 	}
 
 	cat, ok := taxCategoryCodeMap[c.Code]
@@ -73,6 +72,7 @@ func buildDetalleDesglose(c *tax.CategoryTotal, r *tax.RateTotal) (*DetalleDesgl
 		detalle.OperacionExenta = r.Ext[verifactu.ExtKeyExempt].String()
 	} else if r.Ext.Has(verifactu.ExtKeyOpClass) {
 		detalle.CalificacionOperacion = r.Ext.Get(verifactu.ExtKeyOpClass).String()
+		detalle.CuotaRepercutida = r.Amount.String()
 	}
 
 	if detalle.Impuesto == taxCodeIPSI || detalle.Impuesto == taxCodeOther || detalle.ClaveRegimen == "06" {

--- a/doc/breakdown_test.go
+++ b/doc/breakdown_test.go
@@ -63,6 +63,7 @@ func TestBreakdownConversion(t *testing.T) {
 		assert.Equal(t, "100.00", d.Body.VeriFactu.RegistroFactura.RegistroAlta.Desglose.DetalleDesglose[0].BaseImponibleOImporteNoSujeto)
 		assert.Equal(t, "01", d.Body.VeriFactu.RegistroFactura.RegistroAlta.Desglose.DetalleDesglose[0].Impuesto)
 		assert.Equal(t, "E1", d.Body.VeriFactu.RegistroFactura.RegistroAlta.Desglose.DetalleDesglose[0].OperacionExenta)
+		assert.Empty(t, d.Body.VeriFactu.RegistroFactura.RegistroAlta.Desglose.DetalleDesglose[0].CuotaRepercutida)
 	})
 
 	t.Run("multiple-tax-rates", func(t *testing.T) {

--- a/test/data/out/cred-note-exemption.xml
+++ b/test/data/out/cred-note-exemption.xml
@@ -57,7 +57,6 @@
               <sum1:ClaveRegimen>01</sum1:ClaveRegimen>
               <sum1:OperacionExenta>E1</sum1:OperacionExenta>
               <sum1:BaseImponibleOimporteNoSujeto>-10.00</sum1:BaseImponibleOimporteNoSujeto>
-              <sum1:CuotaRepercutida>0.00</sum1:CuotaRepercutida>
             </sum1:DetalleDesglose>
           </sum1:Desglose>
           <sum1:CuotaTotal>-340.20</sum1:CuotaTotal>

--- a/test/data/out/inv-zero-tax.xml
+++ b/test/data/out/inv-zero-tax.xml
@@ -36,7 +36,6 @@
               <sum1:ClaveRegimen>01</sum1:ClaveRegimen>
               <sum1:OperacionExenta>E1</sum1:OperacionExenta>
               <sum1:BaseImponibleOimporteNoSujeto>1800.00</sum1:BaseImponibleOimporteNoSujeto>
-              <sum1:CuotaRepercutida>0.00</sum1:CuotaRepercutida>
             </sum1:DetalleDesglose>
           </sum1:Desglose>
           <sum1:CuotaTotal>0.00</sum1:CuotaTotal>


### PR DESCRIPTION
CuotaRepercutida must be empty when exempt:

https://www.agenciatributaria.es/static_files/AEAT_Desarrolladores/EEDD/IVA/VERI-FACTU/Validaciones_Errores_Veri-Factu.pdf

Page 10, section 15.5