### PR TITLE
Support for REBU, show importeTotal different from Desglose - APP-459

### DIFF
--- a/invoice_registration.go
+++ b/invoice_registration.go
@@ -179,11 +179,15 @@ func newInvoiceRegistration(inv *bill.Invoice, ts time.Time, s *Software) (*Invo
 		reg.FechaOperacion = inv.OperationDate.Time().Format("02-01-2006")
 	}
 
-	// Remove any charges that do not have taxes from the total, these are
-	// likely to be related to payments or other non-taxable items.
+	// Remove untaxed charges from the total. For regimes where ImporteTotal
+	// does not need to match sum(Desglose) (03, 05, 06, 08, 09), only
+	// subtract outlay charges so the total reflects the full sale price.
+	partialBreakdown := hasPartialBreakdownRegime(inv)
 	for _, charge := range inv.Charges {
 		if len(charge.Taxes) == 0 {
-			reg.ImporteTotal = reg.ImporteTotal.Sub(charge.Amount)
+			if !partialBreakdown || charge.Key == bill.ChargeKeyOutlay {
+				reg.ImporteTotal = reg.ImporteTotal.Sub(charge.Amount)
+			}
 		}
 	}
 
@@ -392,4 +396,31 @@ func (r *InvoiceRegistration) ChainData() *ChainData {
 // Bytes prepares an indendented XML document suitable for persistence.
 func (r *InvoiceRegistration) Bytes() ([]byte, error) {
 	return toBytesIndent(r)
+}
+
+// partialBreakdownRegimes lists the ClaveRegimen values where the Desglose
+// only reflects part of the operation (e.g. margin in REBU, markup in travel
+// agencies), so ImporteTotal is not required to match sum(Desglose).
+var partialBreakdownRegimes = []string{"03", "05", "06", "08", "09"}
+
+// hasPartialBreakdownRegime returns true when any non-retained tax rate in
+// the invoice uses a regime where the breakdown is partial.
+func hasPartialBreakdownRegime(inv *bill.Invoice) bool {
+	if inv.Totals == nil || inv.Totals.Taxes == nil {
+		return false
+	}
+	for _, c := range inv.Totals.Taxes.Categories {
+		if c.Retained {
+			continue
+		}
+		for _, r := range c.Rates {
+			regime := r.Ext.Get(verifactu.ExtKeyRegime).String()
+			for _, sr := range partialBreakdownRegimes {
+				if regime == sr {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -7,7 +7,9 @@ import (
 	verifactu "github.com/invopop/gobl.verifactu"
 	"github.com/invopop/gobl.verifactu/test"
 	addon "github.com/invopop/gobl/addons/es/verifactu"
+	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
@@ -144,5 +146,86 @@ func TestNewRegistroAlta(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "10-11-2024", ra.FechaOperacion)
+	})
+}
+
+func TestPartialBreakdownRegime(t *testing.T) {
+	ts, err := time.Parse(time.RFC3339, "2022-02-01T04:00:00Z")
+	require.NoError(t, err)
+	vc, err := verifactu.New(
+		verifactu.Software{},
+		verifactu.WithCurrentTime(ts),
+	)
+	require.NoError(t, err)
+
+	t.Run("REBU keeps untaxed charge in total", func(t *testing.T) {
+		env := test.LoadEnvelope("inv-rebu.json")
+		ra, err := vc.RegisterInvoice(env, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, "10.00", ra.ImporteTotal.String())
+		assert.Equal(t, "0.17", ra.CuotaTotal.String())
+		require.Len(t, ra.Desglose.DetalleDesglose, 1)
+		assert.Equal(t, "03", ra.Desglose.DetalleDesglose[0].ClaveRegimen)
+		assert.Equal(t, "0.83", ra.Desglose.DetalleDesglose[0].BaseImponibleOImporteNoSujeto)
+		assert.Equal(t, "0.17", ra.Desglose.DetalleDesglose[0].CuotaRepercutida)
+	})
+
+	t.Run("REBU with outlay subtracts only the outlay", func(t *testing.T) {
+		env, inv := test.LoadInvoice("inv-rebu.json")
+		inv.Charges = append(inv.Charges, &bill.Charge{
+			Key:    bill.ChargeKeyOutlay,
+			Reason: "Notary fees",
+			Amount: num.MakeAmount(5000, 2),
+		})
+		require.NoError(t, inv.Calculate())
+
+		ra, err := vc.RegisterInvoice(env, nil)
+		require.NoError(t, err)
+
+		// 10.00 (total_with_tax) + 50.00 (outlay) - 50.00 (outlay subtracted) = 10.00
+		assert.Equal(t, "10.00", ra.ImporteTotal.String())
+	})
+
+	t.Run("REBU with multiple untaxed charges keeps all non-outlay", func(t *testing.T) {
+		env, inv := test.LoadInvoice("inv-rebu.json")
+		inv.Charges = append(inv.Charges, &bill.Charge{
+			Reason: "Additional cost component",
+			Amount: num.MakeAmount(2000, 2),
+		})
+		require.NoError(t, inv.Calculate())
+
+		ra, err := vc.RegisterInvoice(env, nil)
+		require.NoError(t, err)
+
+		// Both untaxed charges (9.00 + 20.00) stay in total
+		assert.Equal(t, "30.00", ra.ImporteTotal.String())
+	})
+
+	t.Run("non-partial regime subtracts all untaxed charges", func(t *testing.T) {
+		env := test.LoadEnvelope("inv-base-outlay.json")
+		ra, err := vc.RegisterInvoice(env, nil)
+		require.NoError(t, err)
+
+		// Regime 01: outlay (100.00) subtracted from total_with_tax (2278.00)
+		assert.Equal(t, "2178.00", ra.ImporteTotal.String())
+		assert.Equal(t, "01", ra.Desglose.DetalleDesglose[0].ClaveRegimen)
+	})
+
+	t.Run("non-partial regime subtracts untaxed charge without key", func(t *testing.T) {
+		env, inv := test.LoadInvoice("inv-base.json")
+		inv.Charges = []*bill.Charge{
+			{
+				Reason: "Some non-taxable fee",
+				Amount: num.MakeAmount(10000, 2),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+
+		ra, err := vc.RegisterInvoice(env, nil)
+		require.NoError(t, err)
+
+		// Regime 01: untaxed charge (100.00) subtracted from total_with_tax (2278.00)
+		assert.Equal(t, "2178.00", ra.ImporteTotal.String())
 	})
 }

--- a/test/data/inv-rebu.json
+++ b/test/data/inv-rebu.json
@@ -1,0 +1,123 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "1b03601e8975726d3af55a4bccebc6890c55a453271230b419e97e292fd57e34"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "ES",
+		"$addons": [
+			"es-verifactu-v1"
+		],
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "004",
+		"issue_date": "2024-11-13",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"es-verifactu-doc-type": "F1"
+			}
+		},
+		"supplier": {
+			"name": "Invopop S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B85905495"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "ES",
+				"code": "B63272603"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Used goods profit margin",
+					"price": "0.83"
+				},
+				"sum": "0.83",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%",
+						"ext": {
+							"es-verifactu-op-class": "S1",
+							"es-verifactu-regime": "03"
+						}
+					}
+				],
+				"total": "0.83"
+			}
+		],
+		"charges": [
+			{
+				"i": 1,
+				"reason": "Purchase cost of used goods",
+				"amount": "9.00"
+			}
+		],
+		"totals": {
+			"sum": "0.83",
+			"charge": "9.00",
+			"total": "9.83",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"es-verifactu-op-class": "S1",
+									"es-verifactu-regime": "03"
+								},
+								"base": "0.83",
+								"percent": "21.0%",
+								"amount": "0.17"
+							}
+						],
+						"amount": "0.17"
+					}
+				],
+				"sum": "0.17"
+			},
+			"tax": "0.17",
+			"total_with_tax": "10.00",
+			"payable": "10.00"
+		},
+		"notes": [
+			{
+				"key": "general",
+				"text": "REBU invoice for used goods with regime 03"
+			}
+		]
+	}
+}

--- a/test/data/out/inv-rebu.xml
+++ b/test/data/out/inv-rebu.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sum="https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/tike/cont/ws/SuministroLR.xsd" xmlns:sum1="https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/tike/cont/ws/SuministroInformacion.xsd">
+  <soapenv:Body>
+    <sum:RegFactuSistemaFacturacion>
+      <sum:Cabecera>
+        <sum1:ObligadoEmision>
+          <sum1:NombreRazon>Invopop S.L.</sum1:NombreRazon>
+          <sum1:NIF>B85905495</sum1:NIF>
+        </sum1:ObligadoEmision>
+      </sum:Cabecera>
+      <sum:RegistroFactura>
+        <sum1:RegistroAlta>
+          <sum1:IDVersion>1.0</sum1:IDVersion>
+          <sum1:IDFactura>
+            <sum1:IDEmisorFactura>B85905495</sum1:IDEmisorFactura>
+            <sum1:NumSerieFactura>SAMPLE-004</sum1:NumSerieFactura>
+            <sum1:FechaExpedicionFactura>13-11-2024</sum1:FechaExpedicionFactura>
+          </sum1:IDFactura>
+          <sum1:NombreRazonEmisor>Invopop S.L.</sum1:NombreRazonEmisor>
+          <sum1:TipoFactura>F1</sum1:TipoFactura>
+          <sum1:DescripcionOperacion>REBU invoice for used goods with regime 03</sum1:DescripcionOperacion>
+          <sum1:Destinatarios>
+            <sum1:IDDestinatario>
+              <sum1:NombreRazon>Sample Consumer</sum1:NombreRazon>
+              <sum1:NIF>B63272603</sum1:NIF>
+            </sum1:IDDestinatario>
+          </sum1:Destinatarios>
+          <sum1:Desglose>
+            <sum1:DetalleDesglose>
+              <sum1:Impuesto>01</sum1:Impuesto>
+              <sum1:ClaveRegimen>03</sum1:ClaveRegimen>
+              <sum1:CalificacionOperacion>S1</sum1:CalificacionOperacion>
+              <sum1:TipoImpositivo>21.0</sum1:TipoImpositivo>
+              <sum1:BaseImponibleOimporteNoSujeto>0.83</sum1:BaseImponibleOimporteNoSujeto>
+              <sum1:CuotaRepercutida>0.17</sum1:CuotaRepercutida>
+            </sum1:DetalleDesglose>
+          </sum1:Desglose>
+          <sum1:CuotaTotal>0.17</sum1:CuotaTotal>
+          <sum1:ImporteTotal>10.00</sum1:ImporteTotal>
+          <sum1:Encadenamiento>
+            <sum1:RegistroAnterior>
+              <sum1:IDEmisorFactura>B12345678</sum1:IDEmisorFactura>
+              <sum1:NumSerieFactura>SAMPLE-001</sum1:NumSerieFactura>
+              <sum1:FechaExpedicionFactura>26-11-2024</sum1:FechaExpedicionFactura>
+              <sum1:Huella>0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF</sum1:Huella>
+            </sum1:RegistroAnterior>
+          </sum1:Encadenamiento>
+          <sum1:SistemaInformatico>
+            <sum1:NombreRazon>My Software</sum1:NombreRazon>
+            <sum1:NIF>12345678A</sum1:NIF>
+            <sum1:NombreSistemaInformatico>My Software</sum1:NombreSistemaInformatico>
+            <sum1:IdSistemaInformatico>A1</sum1:IdSistemaInformatico>
+            <sum1:Version>1.0</sum1:Version>
+            <sum1:NumeroInstalacion>12345678A</sum1:NumeroInstalacion>
+            <sum1:TipoUsoPosibleSoloVerifactu>S</sum1:TipoUsoPosibleSoloVerifactu>
+            <sum1:TipoUsoPosibleMultiOT>S</sum1:TipoUsoPosibleMultiOT>
+            <sum1:IndicadorMultiplesOT>N</sum1:IndicadorMultiplesOT>
+          </sum1:SistemaInformatico>
+          <sum1:FechaHoraHusoGenRegistro>2024-11-26T05:00:00+01:00</sum1:FechaHoraHusoGenRegistro>
+          <sum1:TipoHuella>01</sum1:TipoHuella>
+          <sum1:Huella>E8DE029111953EFA29EA4B883FE726E52947BEEBAA64CE7DF9EB19E57262011A</sum1:Huella>
+        </sum1:RegistroAlta>
+      </sum:RegistroFactura>
+    </sum:RegFactuSistemaFacturacion>
+  </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
REBU (Régimen Especial de Bienes Usados) is the Spanish VAT special regime for second-hand goods, art, antiques and collectibles (ClaveRegimen 03). Under REBU, the seller only pays VAT on the profit margin, not the full sale price. This means the tax breakdown (Desglose) only contains the margin, but ImporteTotal must still reflect the full amount the buyer pays.

AEAT's validation rules explicitly exempt regimes 03 (REBU), 05 (travel agencies), 06 (VAT groups), 08 (different regime operations), and 09 (travel agency mediators) from the requirement that ImporteTotal equals the sum of the Desglose.

Previously, all untaxed document charges were subtracted from ImporteTotal. This broke the pattern of using an untaxed charge to represent the purchase cost of the goods (which brings the total up to the full sale price). Now, for these partial breakdown regimes, only outlay charges are subtracted. Other untaxed charges remain in the total. Behavior for standard regimes (01, 02, etc.) is unchanged.